### PR TITLE
Fix: Standardize logger usage in networking directory

### DIFF
--- a/networking/network_manager.cpp
+++ b/networking/network_manager.cpp
@@ -3,7 +3,7 @@
 #include "networking/retransmission_client.h"
 #include "sdk/taifex_sdk.h"
 #include "core_utils/common_header.h"
-#include "core_utils/logger.h"
+#include "logger.h"
 #include "networking/retransmission_protocol.h" // For TaifexRetransmission::DataResponse102 etc.
 
 #include <algorithm> // For std::find_if if needed
@@ -19,28 +19,28 @@ NetworkManager::NetworkManager(Taifex::TaifexSdk* sdk_core_logic)
     if (!sdk_core_logic_) {
         // This is a critical error, NetworkManager cannot function without the SDK logic.
         // Consider throwing an exception or ensuring this condition is never met.
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::CRITICAL, "NetworkManager created with null TaifexSdk pointer!");
+        LOG_CRITICAL << "NetworkManager created with null TaifexSdk pointer!";
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager created.");
+    LOG_INFO << "NetworkManager created.";
 }
 
 NetworkManager::~NetworkManager() {
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager shutting down...");
+    LOG_INFO << "NetworkManager shutting down...";
     stop();
 }
 
 bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
     if (running_.load()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NetworkManager already running. Stop first to reconfigure.");
+        LOG_WARNING << "NetworkManager already running. Stop first to reconfigure.";
         return false;
     }
     config_ = config;
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager configuring...");
+    LOG_INFO << "NetworkManager configuring...";
 
     // Setup Multicast Receivers
     if (config_.multicast_feeds.empty()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "No multicast feeds configured.");
+        LOG_WARNING << "No multicast feeds configured.";
     } else {
         // Primary feed (first in the list)
         const auto& primary_feed_config = config_.multicast_feeds[0];
@@ -50,10 +50,10 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
             }
         );
         if(!primary_multicast_receiver_->add_subscription(primary_feed_config.group_ip, primary_feed_config.port, primary_feed_config.local_interface_ip)) {
-             CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "Failed to add subscription for primary multicast feed: " + primary_feed_config.group_ip);
+             LOG_ERROR << "Failed to add subscription for primary multicast feed: " << primary_feed_config.group_ip;
              primary_multicast_receiver_.reset(); // Nullify if add_subscription failed
         } else {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "Configured primary multicast feed: " + primary_feed_config.group_ip);
+            LOG_INFO << "Configured primary multicast feed: " << primary_feed_config.group_ip;
         }
 
 
@@ -65,13 +65,13 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
                 }
             );
             if(!secondary_multicast_receiver_->add_subscription(secondary_feed_config.group_ip, secondary_feed_config.port, secondary_feed_config.local_interface_ip)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "Failed to add subscription for secondary multicast feed: " + secondary_feed_config.group_ip);
+                LOG_ERROR << "Failed to add subscription for secondary multicast feed: " << secondary_feed_config.group_ip;
                 secondary_multicast_receiver_.reset();
             } else {
-                 CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "Configured secondary multicast feed: " + secondary_feed_config.group_ip);
+                 LOG_INFO << "Configured secondary multicast feed: " << secondary_feed_config.group_ip;
             }
         } else if (config_.dual_feed_enabled && config_.multicast_feeds.size() <= 1) {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "Dual feed enabled but only one or zero multicast feeds configured.");
+            LOG_WARNING << "Dual feed enabled but only one or zero multicast feeds configured.";
         }
     }
 
@@ -86,7 +86,7 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
         if (primary_multicast_receiver_->start()) {
             primary_started = true;
         } else {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "Failed to start primary multicast receiver.");
+            LOG_ERROR << "Failed to start primary multicast receiver.";
             running_ = false;
         }
     }
@@ -96,7 +96,7 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
         if (secondary_multicast_receiver_->start()) {
             secondary_started = true;
         } else {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "Failed to start secondary multicast receiver. Continuing with primary if available.");
+            LOG_ERROR << "Failed to start secondary multicast receiver. Continuing with primary if available.";
             // Not setting running_ to false, can operate in single feed mode
         }
     }
@@ -105,11 +105,11 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
     // Its start method internally launches a thread that tries to connect and login.
 
     if (!primary_started && !secondary_started && !retransmission_client_) { // No data sources configured or started
-         CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NetworkManager started but no functional data sources (multicast/retransmission).");
+         LOG_WARNING << "NetworkManager started but no functional data sources (multicast/retransmission).";
          // running_ might still be true if retransmission was configured but start is async.
          // If primary multicast was configured but failed, running_ would be false.
     } else if (!running_.load()){
-         CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "NetworkManager failed to start essential components.");
+         LOG_ERROR << "NetworkManager failed to start essential components.";
          // cleanup partially started components
          if (primary_multicast_receiver_ && primary_started) primary_multicast_receiver_->stop();
          if (secondary_multicast_receiver_ && secondary_started) secondary_multicast_receiver_->stop();
@@ -117,7 +117,7 @@ bool NetworkManager::configure_and_start(const NetworkManagerConfig& config) {
          return false;
     }
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager started.");
+    LOG_INFO << "NetworkManager started.";
     return running_.load();
 }
 
@@ -126,7 +126,7 @@ void NetworkManager::stop() {
     if (!running_.exchange(false)) { // Set to false and get previous value
         return;
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager stopping...");
+    LOG_INFO << "NetworkManager stopping...";
     if (primary_multicast_receiver_) {
         primary_multicast_receiver_->stop();
     }
@@ -136,7 +136,7 @@ void NetworkManager::stop() {
     if (retransmission_client_) {
         retransmission_client_->stop();
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NetworkManager stopped.");
+    LOG_INFO << "NetworkManager stopped.";
 }
 
 void NetworkManager::on_primary_multicast_data(const unsigned char* data, size_t length,
@@ -155,7 +155,7 @@ void NetworkManager::process_incoming_packet(const unsigned char* data, size_t l
 
     CoreUtils::CommonHeader header;
     if (!CoreUtils::CommonHeader::parse(data, length, header)) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: Dropping packet - failed to parse common header. Source: " + (is_retransmitted ? "Retrans" : (is_from_primary_feed ? "PrimaryMC" : "SecondaryMC")));
+        LOG_WARNING << "NM: Dropping packet - failed to parse common header. Source: " << (is_retransmitted ? "Retrans" : (is_from_primary_feed ? "PrimaryMC" : "SecondaryMC"));
         return;
     }
     uint32_t channel_id = header.getChannelId();
@@ -169,8 +169,8 @@ void NetworkManager::process_incoming_packet(const unsigned char* data, size_t l
         if (it != deduplication_log_.end()) {
             // Optional: Check timestamp if it's within a very small window of the first arrival to allow for network jitter
             // if (now - it->second < DEDUPLICATION_TIME_WINDOW_MS) { // Example time window check
-                 CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "NM: Duplicate packet on Channel " + std::to_string(channel_id) +
-                                   " Seq " + std::to_string(channel_seq) + " from " + (is_from_primary_feed ? "primary" : "secondary") + ". Discarding.");
+                 LOG_DEBUG << "NM: Duplicate packet on Channel " << channel_id <<
+                                   " Seq " << channel_seq << " from " << (is_from_primary_feed ? "primary" : "secondary") << ". Discarding.";
                 return;
             // } else {
             //     // Seen before but outside time window, treat as new (or log as stale duplicate)
@@ -192,7 +192,7 @@ void NetworkManager::process_incoming_packet(const unsigned char* data, size_t l
 
 void NetworkManager::on_retransmitted_market_data(const unsigned char* data, size_t length) {
     if (!running_.load() || !sdk_core_logic_) return;
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "NM: Received retransmitted market data (len: " + std::to_string(length) + ")");
+    LOG_DEBUG << "NM: Received retransmitted market data (len: " << length << ")";
     process_incoming_packet(data, length, false /*is_primary, doesn't matter*/, true /*is_retransmitted*/);
 }
 
@@ -205,19 +205,19 @@ void NetworkManager::forward_to_sdk(const unsigned char* data, size_t length) {
 
 void NetworkManager::trigger_retransmission_request(uint16_t channel_id, uint32_t start_seq_num, uint16_t count) {
     if (!running_.load()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: Cannot trigger retransmission, NetworkManager not running.");
+        LOG_WARNING << "NM: Cannot trigger retransmission, NetworkManager not running.";
         return;
     }
     if (retransmission_client_) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Triggering retransmission for Channel " + std::to_string(channel_id) +
-                               " from Seq " + std::to_string(start_seq_num) + ", Count " + std::to_string(count));
+        LOG_INFO << "NM: Triggering retransmission for Channel " << channel_id <<
+                               " from Seq " << start_seq_num << ", Count " << count;
         if(!retransmission_client_->request_retransmission(channel_id, start_seq_num, count)) {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: Failed to send retransmission request. Client might not be logged in or connected.");
+            LOG_WARNING << "NM: Failed to send retransmission request. Client might not be logged in or connected.";
             // Optionally, try to connect/login retransmission client again if it's not in a good state
             // This could be complex if the client is already in its reconnect loop.
         }
     } else {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: Retransmission client not configured, cannot request retransmission.");
+        LOG_WARNING << "NM: Retransmission client not configured, cannot request retransmission.";
     }
 }
 
@@ -235,41 +235,41 @@ void NetworkManager::connect_retransmission_client(bool use_primary_server) {
             [this](const TaifexRetransmission::DataResponse102& resp, const std::vector<unsigned char>& retrans_data) { this->on_retransmission_status(resp); }, // Adjusted for new sig
             [this](const TaifexRetransmission::ErrorNotification010& err_msg) { this->on_retransmission_error(err_msg); }, // Adjusted
             [this]() { this->on_retransmission_disconnected(); },
-            [this]() { CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Retransmission client logged in to " + (retrans_primary_active_ ? "primary" : "backup") + " server.");}
+            [this]() { LOG_INFO << "NM: Retransmission client logged in to " << (retrans_primary_active_ ? "primary" : "backup") << " server.";}
         );
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Configured " + server_type + " retransmission server: " + server_config_opt->ip);
+        LOG_INFO << "NM: Configured " << server_type << " retransmission server: " << server_config_opt->ip;
         if (!retransmission_client_->start()) {
-             CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "NM: Failed to start retransmission client for " + server_type + " server.");
+             LOG_ERROR << "NM: Failed to start retransmission client for " << server_type << " server.";
         }
     } else {
-         CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: No " + server_type + " retransmission server configured.");
+         LOG_WARNING << "NM: No " << server_type << " retransmission server configured.";
     }
 }
 
 
 // Other callback implementations (on_retransmission_status, etc.)
 void NetworkManager::on_retransmission_status(const TaifexRetransmission::DataResponse102& response) { // Added retrans_data
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Retransmission status update. Channel: " + std::to_string(response.channel_id) +
-                           ", Status: " + std::to_string(response.status_code) +
-                           ", BeginSeq: " + std::to_string(response.begin_seq_no) +
-                           ", RecoverNum: " + std::to_string(response.recover_num));
+    LOG_INFO << "NM: Retransmission status update. Channel: " << response.channel_id <<
+                           ", Status: " << response.status_code <<
+                           ", BeginSeq: " << response.begin_seq_no <<
+                           ", RecoverNum: " << response.recover_num;
     // If DataResponse102 status indicates an error (e.g. "no data", "request error"),
     // this might be where logic to switch to a backup retransmission server could be triggered,
     // or to notify the application layer of failure to recover.
 }
 
 void NetworkManager::on_retransmission_error(const TaifexRetransmission::ErrorNotification010& error_msg) { // Changed to take struct
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "NM: Retransmission client error notification. Status Code: " + std::to_string(error_msg.status_code));
+    LOG_ERROR << "NM: Retransmission client error notification. Status Code: " << error_msg.status_code;
     // ErrorNotification 010 from server usually means server will disconnect.
     // RetransmissionClient's receive_loop should detect this and call on_retransmission_disconnected.
 }
 
 void NetworkManager::on_retransmission_disconnected() {
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "NM: Retransmission client disconnected.");
+    LOG_WARNING << "NM: Retransmission client disconnected.";
     // Simple strategy: if primary was active and backup is configured, try switching to backup.
     // More complex logic would involve retry counts, timers, etc.
     if (retrans_primary_active_ && config_.backup_retrans_server) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Primary retransmission server disconnected. Attempting to switch to backup.");
+        LOG_INFO << "NM: Primary retransmission server disconnected. Attempting to switch to backup.";
         if (retransmission_client_) { // Stop existing client first
             retransmission_client_->stop();
         }
@@ -277,7 +277,7 @@ void NetworkManager::on_retransmission_disconnected() {
         connect_retransmission_client(retrans_primary_active_);
     } else if (!retrans_primary_active_ && config_.primary_retrans_server) {
         // Was on backup, try switching back to primary (or just keep retrying current one via its internal loop)
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "NM: Backup retransmission server disconnected. RetransmissionClient will attempt to reconnect.");
+        LOG_INFO << "NM: Backup retransmission server disconnected. RetransmissionClient will attempt to reconnect.";
         // RetransmissionClient's own receive_loop will try to reconnect to its configured server.
         // If we want NetworkManager to manage failover back to primary, more state is needed.
     }

--- a/networking/retransmission_client.cpp
+++ b/networking/retransmission_client.cpp
@@ -1,6 +1,6 @@
 #include "networking/retransmission_client.h"
 #include "networking/endian_utils.h"
-#include "core_utils/logger.h"
+#include "logger.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -40,11 +40,11 @@ RetransmissionClient::RetransmissionClient(
       connected_(false),
       logged_in_(false),
       client_msg_seq_num_(0) {
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient created for " + server_ip_ + ":" + std::to_string(server_port_));
+    LOG_INFO << "RetransmissionClient created for " << server_ip_ << ":" << server_port_;
 }
 
 RetransmissionClient::~RetransmissionClient() {
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient for " + server_ip_ + " shutting down...");
+    LOG_INFO << "RetransmissionClient for " << server_ip_ << " shutting down...";
     stop();
 }
 
@@ -61,7 +61,7 @@ bool RetransmissionClient::connect_to_server() {
 
     socket_fd_ = socket(AF_INET, SOCK_STREAM, 0);
     if (socket_fd_ < 0) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to create TCP socket: " + std::string(strerror(errno)));
+        LOG_ERROR << "RetransmissionClient: Failed to create TCP socket: " << strerror(errno);
         return false;
     }
 
@@ -70,15 +70,15 @@ bool RetransmissionClient::connect_to_server() {
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_port = htons(server_port_);
     if (inet_pton(AF_INET, server_ip_.c_str(), &serv_addr.sin_addr) <= 0) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Invalid server IP address: " + server_ip_);
+        LOG_ERROR << "RetransmissionClient: Invalid server IP address: " << server_ip_;
         close(socket_fd_);
         socket_fd_ = -1;
         return false;
     }
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Connecting to " + server_ip_ + ":" + std::to_string(server_port_) + "...");
+    LOG_INFO << "RetransmissionClient: Connecting to " << server_ip_ << ":" << server_port_ << "...";
     if (connect(socket_fd_, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Connection failed to " + server_ip_ + ":" + std::to_string(server_port_) + ": " + std::string(strerror(errno)));
+        LOG_ERROR << "RetransmissionClient: Connection failed to " << server_ip_ << ":" << server_port_ << ": " << strerror(errno);
         close(socket_fd_);
         socket_fd_ = -1;
         return false;
@@ -88,21 +88,21 @@ bool RetransmissionClient::connect_to_server() {
     tv.tv_sec = DEFAULT_RECV_TIMEOUT_SEC;
     tv.tv_usec = 0;
     if (setsockopt(socket_fd_, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv) < 0) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Failed to set SO_RCVTIMEO. Recv calls may block longer than expected.");
+        LOG_WARNING << "RetransmissionClient: Failed to set SO_RCVTIMEO. Recv calls may block longer than expected.";
     }
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Connected successfully to " + server_ip_ + ":" + std::to_string(server_port_));
+    LOG_INFO << "RetransmissionClient: Connected successfully to " << server_ip_ << ":" << server_port_;
     connected_ = true;
     return true;
 }
 
 bool RetransmissionClient::perform_login() {
     if (!connected_.load()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Not connected, cannot perform login.");
+        LOG_WARNING << "RetransmissionClient: Not connected, cannot perform login.";
         return false;
     }
     if (logged_in_.load()) {
-         CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Already logged in.");
+         LOG_INFO << "RetransmissionClient: Already logged in.";
         return true;
     }
 
@@ -126,7 +126,7 @@ bool RetransmissionClient::perform_login() {
     std::vector<unsigned char> buffer;
     login_req.serialize(buffer, password_);
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Sending LoginRequest020 (MsgSeq: " + std::to_string(login_req.header.msg_seq_num) + ")");
+    LOG_INFO << "RetransmissionClient: Sending LoginRequest020 (MsgSeq: " << login_req.header.msg_seq_num << ")";
     send_tcp_message(buffer);
 
     return true;
@@ -135,7 +135,7 @@ bool RetransmissionClient::perform_login() {
 
 void RetransmissionClient::send_tcp_message(const std::vector<unsigned char>& message_bytes) {
     if (!connected_.load() || socket_fd_ < 0) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Not connected, cannot send message.");
+        LOG_ERROR << "RetransmissionClient: Not connected, cannot send message.";
         // error_callback_ might be too strong here, as it's for protocol errors. Disconnected is more appropriate.
         // If not connected, the receive_loop should handle invoking disconnected_callback_.
         return;
@@ -148,7 +148,7 @@ void RetransmissionClient::send_tcp_message(const std::vector<unsigned char>& me
     while (total_sent < message_bytes.size()) {
         ssize_t sent_this_call = send(socket_fd_, data_ptr + total_sent, remaining, 0);
         if (sent_this_call < 0) {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: send() error: " + std::string(strerror(errno)));
+            LOG_ERROR << "RetransmissionClient: send() error: " << strerror(errno);
             close(socket_fd_); // Close socket on send error
             socket_fd_ = -1;
             connected_ = false;
@@ -157,7 +157,7 @@ void RetransmissionClient::send_tcp_message(const std::vector<unsigned char>& me
             return;
         }
         if (sent_this_call == 0) { // Should not happen with blocking socket unless error
-             CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: send() returned 0, treating as disconnect.");
+             LOG_ERROR << "RetransmissionClient: send() returned 0, treating as disconnect.";
             close(socket_fd_);
             socket_fd_ = -1;
             connected_ = false;
@@ -168,25 +168,25 @@ void RetransmissionClient::send_tcp_message(const std::vector<unsigned char>& me
         total_sent += sent_this_call;
         remaining -= sent_this_call;
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Sent " + std::to_string(total_sent) + " bytes.");
+    LOG_DEBUG << "RetransmissionClient: Sent " << total_sent << " bytes.";
 }
 
 
 void RetransmissionClient::receive_loop() {
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Receive loop started for " + server_ip_);
+    LOG_INFO << "RetransmissionClient: Receive loop started for " << server_ip_;
     const size_t RECV_BUFFER_SIZE = 8192;
     std::vector<unsigned char> temp_recv_buf(RECV_BUFFER_SIZE);
 
     while (running_.load()) {
         if (!connected_.load() || socket_fd_ < 0) {
             if (!running_.load()) break;
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Not connected. Attempting to reconnect...");
+            LOG_INFO << "RetransmissionClient: Not connected. Attempting to reconnect...";
             std::this_thread::sleep_for(std::chrono::seconds(5));
             if (!connect_to_server()) {
                 continue;
             }
             if (!perform_login()) {
-                 CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Re-login attempt initiated, awaiting response.");
+                 LOG_WARNING << "RetransmissionClient: Re-login attempt initiated, awaiting response.";
             }
         }
 
@@ -204,10 +204,10 @@ void RetransmissionClient::receive_loop() {
                 continue;
             }
             if (!running_.load() && (errno == EINTR || errno == EBADF)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: recv interrupted or socket closed, likely due to stop().");
+                LOG_INFO << "RetransmissionClient: recv interrupted or socket closed, likely due to stop().";
                 break;
             }
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: recv() error: " + std::string(strerror(errno)));
+            LOG_ERROR << "RetransmissionClient: recv() error: " << strerror(errno);
             close(socket_fd_);
             socket_fd_ = -1;
             connected_ = false;
@@ -217,7 +217,7 @@ void RetransmissionClient::receive_loop() {
         }
 
         if (bytes_received == 0) {
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Server closed connection.");
+            LOG_INFO << "RetransmissionClient: Server closed connection.";
             close(socket_fd_);
             socket_fd_ = -1;
             connected_ = false;
@@ -231,18 +231,18 @@ void RetransmissionClient::receive_loop() {
             process_incoming_data(temp_recv_buf.data(), static_cast<size_t>(bytes_received));
         }
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Receive loop ended for " + server_ip_);
+    LOG_INFO << "RetransmissionClient: Receive loop ended for " << server_ip_;
 }
 
 
 bool RetransmissionClient::start() {
     if (running_.exchange(true)) { // Set to true and get previous value
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Already running or start signal sent.");
+        LOG_WARNING << "RetransmissionClient: Already running or start signal sent.";
         return true;
     }
     // Thread will handle connect and login sequence
     client_thread_ = std::make_unique<std::thread>(&RetransmissionClient::receive_loop, this);
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Started and attempting connection/login.");
+    LOG_INFO << "RetransmissionClient: Started and attempting connection/login.";
     return true;
 }
 
@@ -250,7 +250,7 @@ void RetransmissionClient::stop() {
     if (!running_.exchange(false)) { // Set to false and get previous value
         return; // Already stopped or stop signal sent
     }
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Stopping...");
+    LOG_INFO << "RetransmissionClient: Stopping...";
 
     if (socket_fd_ >= 0) {
         // No need for shutdown() typically before close() for client sockets unless specific linger options are set.
@@ -265,7 +265,7 @@ void RetransmissionClient::stop() {
 
     connected_ = false;
     logged_in_ = false;
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Stopped.");
+    LOG_INFO << "RetransmissionClient: Stopped.";
 }
 
 #include "core_utils/common_header.h"     // For parsing retransmitted market data headers
@@ -278,7 +278,7 @@ namespace Networking {
 
 bool RetransmissionClient::request_retransmission(uint16_t channel_id, uint32_t begin_seq_no, uint16_t count) {
     if (!logged_in_.load()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Not logged in, cannot send DataRequest101.");
+        LOG_WARNING << "RetransmissionClient: Not logged in, cannot send DataRequest101.";
         // error_callback_ might be too generic here. This is a client-side state issue.
         // Consider just returning false or logging. For now, let's not call error_callback_.
         return false;
@@ -300,15 +300,15 @@ bool RetransmissionClient::request_retransmission(uint16_t channel_id, uint32_t 
     std::vector<unsigned char> buffer;
     req.serialize(buffer);
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Sending DataRequest101 (ClientMsgSeq: " + std::to_string(req.header.msg_seq_num) +
-                           ", Channel: " + std::to_string(channel_id) + ", Begin: " + std::to_string(begin_seq_no) + ", Count: " + std::to_string(count) + ")");
+    LOG_INFO << "RetransmissionClient: Sending DataRequest101 (ClientMsgSeq: " << req.header.msg_seq_num <<
+                           ", Channel: " << channel_id << ", Begin: " << begin_seq_no << ", Count: " << count << ")";
     send_tcp_message(buffer);
     return true;
 }
 
 bool RetransmissionClient::send_client_heartbeat() { // Renamed for clarity in header
     if (!connected_.load()) {
-        CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Not connected, cannot send HeartbeatClient105.");
+        LOG_WARNING << "RetransmissionClient: Not connected, cannot send HeartbeatClient105.";
         return false;
     }
 
@@ -324,7 +324,7 @@ bool RetransmissionClient::send_client_heartbeat() { // Renamed for clarity in h
     std::vector<unsigned char> buffer;
     hb_resp.serialize(buffer);
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Sending HeartbeatClient105 (ClientMsgSeq: " + std::to_string(hb_resp.header.msg_seq_num) + ")");
+    LOG_INFO << "RetransmissionClient: Sending HeartbeatClient105 (ClientMsgSeq: " << hb_resp.header.msg_seq_num << ")";
     send_tcp_message(buffer);
     return true;
 }
@@ -338,7 +338,7 @@ void RetransmissionClient::process_incoming_data(const unsigned char* data_chunk
 
         if (current_data[0] == 0x1B) { // Potential Market Data Message (starts with ESC)
             if (current_size < CoreUtils::CommonHeader::HEADER_SIZE) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Buffer has 0x1B but not enough data for market data header. Size: " + std::to_string(current_size));
+                LOG_DEBUG << "RetransmissionClient: Buffer has 0x1B but not enough data for market data header. Size: " << current_size;
                 break;
             }
             CoreUtils::CommonHeader market_header;
@@ -350,25 +350,25 @@ void RetransmissionClient::process_incoming_data(const unsigned char* data_chunk
                 size_t full_market_msg_len = CoreUtils::CommonHeader::HEADER_SIZE + market_body_len + 1 + 2; // +checksum+term_code
 
                 if (current_size >= full_market_msg_len) {
-                    CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Received retransmitted market data message (len: " + std::to_string(full_market_msg_len) + ")");
+                    LOG_DEBUG << "RetransmissionClient: Received retransmitted market data message (len: " << full_market_msg_len << ")";
                     if (market_data_callback_) {
                         market_data_callback_(current_data, full_market_msg_len);
                     }
                     tcp_receive_buffer_.erase(tcp_receive_buffer_.begin(), tcp_receive_buffer_.begin() + full_market_msg_len);
                     continue;
                 } else {
-                    CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Buffer has market data header, but needs more data for full message. Have: " + std::to_string(current_size) + ", Need: " + std::to_string(full_market_msg_len));
+                    LOG_DEBUG << "RetransmissionClient: Buffer has market data header, but needs more data for full message. Have: " << current_size << ", Need: " << full_market_msg_len;
                     break;
                 }
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Data starts with 0x1B but not a valid market data header. Buffer size: " + std::to_string(current_size) + ". Clearing buffer to prevent loop.");
+                LOG_ERROR << "RetransmissionClient: Data starts with 0x1B but not a valid market data header. Buffer size: " << current_size << ". Clearing buffer to prevent loop.";
                 tcp_receive_buffer_.clear();
                 break;
             }
         } else { // Assume Retransmission Protocol Message
             // Need at least enough for the MsgSize field of the retransmission header to know message length.
             if (current_size < sizeof(uint16_t)) { // sizeof(RetransmissionMsgHeader::msg_size)
-                 CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Buffer too small for even retrans MsgSize field. Size: " + std::to_string(current_size));
+                 LOG_DEBUG << "RetransmissionClient: Buffer too small for even retrans MsgSize field. Size: " << current_size;
                 break;
             }
 
@@ -388,7 +388,7 @@ void RetransmissionClient::process_incoming_data(const unsigned char* data_chunk
                 // ensuring it doesn't read past what we know is a full message or buffer end.
                 // Since we determined expected_retrans_msg_len is available, use that.
                 if (!retrans_header.deserialize(current_data, temp_offset, expected_retrans_msg_len)) {
-                     CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize retransmission message header from complete segment.");
+                     LOG_ERROR << "RetransmissionClient: Failed to deserialize retransmission message header from complete segment.";
                      tcp_receive_buffer_.erase(tcp_receive_buffer_.begin(), tcp_receive_buffer_.begin() + expected_retrans_msg_len); // Remove malformed part
                      continue; // Try next message if any
                 }
@@ -399,7 +399,7 @@ void RetransmissionClient::process_incoming_data(const unsigned char* data_chunk
                 tcp_receive_buffer_.erase(tcp_receive_buffer_.begin(), tcp_receive_buffer_.begin() + expected_retrans_msg_len);
                 continue;
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Buffer has start of retrans message, but needs more data. Have: " + std::to_string(current_size) + ", Need: " + std::to_string(expected_retrans_msg_len));
+                LOG_DEBUG << "RetransmissionClient: Buffer has start of retrans message, but needs more data. Have: " << current_size << ", Need: " << expected_retrans_msg_len;
                 break;
             }
         }
@@ -410,26 +410,26 @@ void RetransmissionClient::handle_protocol_message(
     const TaifexRetransmission::RetransmissionMsgHeader& temp_parsed_header,
     const unsigned char* full_message_data, size_t full_message_length) {
 
-    CoreUtils::Logger::Log(CoreUtils::LogLevel::DEBUG, "RetransmissionClient: Handling protocol message type: " + std::to_string(temp_parsed_header.msg_type));
+    LOG_DEBUG << "RetransmissionClient: Handling protocol message type: " << temp_parsed_header.msg_type;
 
     switch (temp_parsed_header.msg_type) {
         case TaifexRetransmission::LoginResponse030::MESSAGE_TYPE: {
             TaifexRetransmission::LoginResponse030 msg;
             if (msg.deserialize(full_message_data, full_message_length)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Received LoginResponse030 for ChannelID: " + std::to_string(msg.channel_id));
+                LOG_INFO << "RetransmissionClient: Received LoginResponse030 for ChannelID: " << msg.channel_id;
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize LoginResponse030.");
+                LOG_ERROR << "RetransmissionClient: Failed to deserialize LoginResponse030.";
             }
             break;
         }
         case TaifexRetransmission::RetransmissionStart050::MESSAGE_TYPE: {
             TaifexRetransmission::RetransmissionStart050 msg;
             if (msg.deserialize(full_message_data, full_message_length)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Received RetransmissionStart050. Login successful.");
+                LOG_INFO << "RetransmissionClient: Received RetransmissionStart050. Login successful.";
                 logged_in_ = true;
                 if (logged_in_callback_) logged_in_callback_();
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize RetransmissionStart050.");
+                LOG_ERROR << "RetransmissionClient: Failed to deserialize RetransmissionStart050.";
             }
             break;
         }
@@ -438,40 +438,40 @@ void RetransmissionClient::handle_protocol_message(
             std::vector<unsigned char> retransmitted_data_payload; // To store variable part
             // Pass password_ as empty string as it's not used by DataResponse102::deserialize
             if (msg.deserialize(full_message_data, full_message_length, retransmitted_data_payload)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Received DataResponse102. Status: " + std::to_string(msg.status_code) +
-                                       " for Channel: " + std::to_string(msg.channel_id) + ", BeginSeq: " + std::to_string(msg.begin_seq_no) +
-                                       ", Retransmitted data size: " + std::to_string(retransmitted_data_payload.size()));
+                LOG_INFO << "RetransmissionClient: Received DataResponse102. Status: " << msg.status_code <<
+                                       " for Channel: " << msg.channel_id << ", BeginSeq: " << msg.begin_seq_no <<
+                                       ", Retransmitted data size: " << retransmitted_data_payload.size();
                 if (status_callback_) status_callback_(msg, retransmitted_data_payload);
                 // After DataResponse102 with status 0, server sends market data messages directly (0x1B type).
                 // These will be handled by the market data path in process_incoming_data.
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize DataResponse102.");
+                LOG_ERROR << "RetransmissionClient: Failed to deserialize DataResponse102.";
             }
             break;
         }
         case TaifexRetransmission::HeartbeatServer104::MESSAGE_TYPE: {
             TaifexRetransmission::HeartbeatServer104 msg;
              if (msg.deserialize(full_message_data, full_message_length)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::INFO, "RetransmissionClient: Received HeartbeatServer104. Sending response.");
+                LOG_INFO << "RetransmissionClient: Received HeartbeatServer104. Sending response.";
                 send_client_heartbeat();
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize HeartbeatServer104.");
+                LOG_ERROR << "RetransmissionClient: Failed to deserialize HeartbeatServer104.";
             }
             break;
         }
         case TaifexRetransmission::ErrorNotification010::MESSAGE_TYPE: {
             TaifexRetransmission::ErrorNotification010 msg;
             if (msg.deserialize(full_message_data, full_message_length)) {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Received ErrorNotification010. Status: " + std::to_string(msg.status_code));
+                LOG_ERROR << "RetransmissionClient: Received ErrorNotification010. Status: " << msg.status_code;
                 if (error_callback_) error_callback_(msg); // Changed to pass struct
                 logged_in_ = false;
             } else {
-                CoreUtils::Logger::Log(CoreUtils::LogLevel::ERROR, "RetransmissionClient: Failed to deserialize ErrorNotification010.");
+                LOG_ERROR << "RetransmissionClient: Failed to deserialize ErrorNotification010.";
             }
             break;
         }
         default:
-            CoreUtils::Logger::Log(CoreUtils::LogLevel::WARNING, "RetransmissionClient: Received unknown retransmission protocol message type: " + std::to_string(temp_parsed_header.msg_type));
+            LOG_WARNING << "RetransmissionClient: Received unknown retransmission protocol message type: " << temp_parsed_header.msg_type;
             break;
     }
 }


### PR DESCRIPTION
This commit addresses several issues related to logger usage within the 'networking' directory:

1.  Corrected include paths for 'logger.h':
    - Changed #include "core_utils/logger.h" to #include "logger.h" in all relevant .cpp files (retransmission_client.cpp, network_manager.cpp) to align with your project's include structure for core_utils.

2.  Updated logging call style:
    - Replaced outdated static calls like CoreUtils::Logger::Log(...) with the correct macro-based stream logging (e.g., LOG_ERROR << "message") as defined in logger.h. This was applied to retransmission_client.cpp and network_manager.cpp.

These changes ensure consistent and correct logger usage across the networking module and resolve all related compilation errors.